### PR TITLE
feat: add CityGML 2.0 reading support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ set(TARGET_NAME cityjson)
 # used in cmake with find_package. Feel free to remove or replace with other dependencies.
 # Note that it should also be removed from vcpkg.json to prevent needlessly installing it..
 find_package(nlohmann_json REQUIRED)
+find_package(pugixml REQUIRED)
 
 set(EXTENSION_NAME ${TARGET_NAME}_extension)
 set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
@@ -32,6 +33,7 @@ set(EXTENSION_SOURCES
     src/cityjson/local_cityjson_reader.cpp
     src/cityjson/local_cityjsonseq_reader.cpp
     src/cityjson/reader_factory.cpp
+    src/cityjson/citygml_reader.cpp
     # Geometry encoding layer
     src/cityjson/wkb_encoder.cpp
     src/cityjson/wkb_decoder.cpp
@@ -288,14 +290,17 @@ find_package(OpenSSL REQUIRED)
 # Link OpenSSL and nlohmann_json in both the static library and the loadable extension
 # Use imported targets if available, fall back to raw variables otherwise
 if(TARGET OpenSSL::SSL)
-  set_property(TARGET ${EXTENSION_NAME} APPEND PROPERTY LINK_LIBRARIES OpenSSL::SSL OpenSSL::Crypto nlohmann_json::nlohmann_json)
-  set_property(TARGET ${LOADABLE_EXTENSION_NAME} APPEND PROPERTY LINK_LIBRARIES OpenSSL::SSL OpenSSL::Crypto nlohmann_json::nlohmann_json)
+  set_property(TARGET ${EXTENSION_NAME} APPEND PROPERTY LINK_LIBRARIES OpenSSL::SSL OpenSSL::Crypto nlohmann_json::nlohmann_json pugixml::pugixml)
+  set_property(TARGET ${LOADABLE_EXTENSION_NAME} APPEND PROPERTY LINK_LIBRARIES OpenSSL::SSL OpenSSL::Crypto nlohmann_json::nlohmann_json pugixml::pugixml)
 else()
   target_include_directories(${EXTENSION_NAME} PRIVATE ${OPENSSL_INCLUDE_DIR})
   target_include_directories(${LOADABLE_EXTENSION_NAME} PRIVATE ${OPENSSL_INCLUDE_DIR})
-  set_property(TARGET ${EXTENSION_NAME} APPEND PROPERTY LINK_LIBRARIES ${OPENSSL_LIBRARIES} nlohmann_json::nlohmann_json)
-  set_property(TARGET ${LOADABLE_EXTENSION_NAME} APPEND PROPERTY LINK_LIBRARIES ${OPENSSL_LIBRARIES} nlohmann_json::nlohmann_json)
+  set_property(TARGET ${EXTENSION_NAME} APPEND PROPERTY LINK_LIBRARIES ${OPENSSL_LIBRARIES} nlohmann_json::nlohmann_json pugixml::pugixml)
+  set_property(TARGET ${LOADABLE_EXTENSION_NAME} APPEND PROPERTY LINK_LIBRARIES ${OPENSSL_LIBRARIES} nlohmann_json::nlohmann_json pugixml::pugixml)
 endif()
+
+# Propagate pugixml to targets linking the static extension (e.g. duckdb shell)
+set_property(TARGET ${EXTENSION_NAME} APPEND PROPERTY INTERFACE_LINK_LIBRARIES pugixml::pugixml)
 
 install(
   TARGETS ${EXTENSION_NAME}

--- a/src/cityjson/citygml_reader.cpp
+++ b/src/cityjson/citygml_reader.cpp
@@ -1,0 +1,911 @@
+#include "cityjson/citygml_reader.hpp"
+#include "cityjson/city_object_utils.hpp"
+#include <sstream>
+#include <cstdio>
+#include <algorithm>
+#include <cctype>
+
+namespace duckdb {
+namespace cityjson {
+
+// ============================================================
+// Constructors
+// ============================================================
+
+LocalCityGMLReader::LocalCityGMLReader(const std::string &file_path, size_t sample_lines)
+    : file_path_(file_path), sample_lines_(sample_lines) {
+}
+
+LocalCityGMLReader::LocalCityGMLReader(const std::string &name, std::string content, size_t sample_lines)
+    : file_path_(name), sample_lines_(sample_lines), content_(std::move(content)) {
+}
+
+// ============================================================
+// Name
+// ============================================================
+
+std::string LocalCityGMLReader::Name() const {
+	return file_path_;
+}
+
+// ============================================================
+// Helpers
+// ============================================================
+
+std::string LocalCityGMLReader::LocalName(const char *name) {
+	std::string s(name);
+	auto pos = s.find(':');
+	if (pos != std::string::npos) {
+		return s.substr(pos + 1);
+	}
+	return s;
+}
+
+pugi::xml_document LocalCityGMLReader::LoadXML() const {
+	pugi::xml_document doc;
+	pugi::xml_parse_result result;
+
+	if (content_.has_value()) {
+		result = doc.load_string(content_.value().c_str());
+	} else {
+		result = doc.load_file(file_path_.c_str());
+	}
+
+	if (!result) {
+		throw CityJSONError::Parse("Failed to parse CityGML XML: " + std::string(result.description()), file_path_);
+	}
+
+	return doc;
+}
+
+std::optional<CRS> LocalCityGMLReader::ParseSrsName(const std::string &srs) {
+	if (srs.empty()) {
+		return std::nullopt;
+	}
+
+	// Handle URN format: "urn:ogc:def:crs:EPSG::7415"
+	if (srs.substr(0, 4) == "urn:") {
+		auto last_colon = srs.rfind(':');
+		if (last_colon != std::string::npos && last_colon + 1 < srs.size()) {
+			std::string code = srs.substr(last_colon + 1);
+			if (srs.find("EPSG") != std::string::npos) {
+				return CRS("EPSG:" + code, "EPSG", code);
+			}
+		}
+	}
+
+	// Handle simple "EPSG:XXXX" format
+	if (srs.substr(0, 5) == "EPSG:") {
+		std::string code = srs.substr(5);
+		return CRS("EPSG:" + code, "EPSG", code);
+	}
+
+	// Handle OGC HTTP URI: "http://www.opengis.net/def/crs/EPSG/0/4326"
+	auto epsg_pos = srs.find("EPSG");
+	if (epsg_pos != std::string::npos) {
+		auto last_slash = srs.rfind('/');
+		if (last_slash != std::string::npos && last_slash + 1 < srs.size()) {
+			std::string code = srs.substr(last_slash + 1);
+			return CRS("EPSG:" + code, "EPSG", code);
+		}
+	}
+
+	// Fall back to storing the full string as the name
+	return CRS(srs);
+}
+
+uint32_t LocalCityGMLReader::AddVertex(double x, double y, double z,
+                                       std::vector<std::array<double, 3>> &vertex_pool,
+                                       std::unordered_map<std::string, uint32_t> &vertex_index) {
+	char buf[128];
+	snprintf(buf, sizeof(buf), "%.15g,%.15g,%.15g", x, y, z);
+	std::string key(buf);
+
+	auto it = vertex_index.find(key);
+	if (it != vertex_index.end()) {
+		return it->second;
+	}
+
+	auto idx = static_cast<uint32_t>(vertex_pool.size());
+	vertex_pool.push_back({x, y, z});
+	vertex_index[key] = idx;
+	return idx;
+}
+
+std::vector<std::array<double, 3>> LocalCityGMLReader::ParsePosList(const std::string &text, int srs_dimension) {
+	std::vector<std::array<double, 3>> coords;
+	std::istringstream iss(text);
+	double val;
+	std::vector<double> values;
+
+	while (iss >> val) {
+		values.push_back(val);
+	}
+
+	for (size_t i = 0; i + srs_dimension <= values.size(); i += srs_dimension) {
+		double x = values[i];
+		double y = values[i + 1];
+		double z = (srs_dimension >= 3) ? values[i + 2] : 0.0;
+		coords.push_back({x, y, z});
+	}
+
+	return coords;
+}
+
+// ============================================================
+// LOD tag parsing
+// ============================================================
+
+std::optional<std::pair<std::string, std::string>> LocalCityGMLReader::ParseLODTag(const std::string &local_name) {
+	// Match pattern: "lod<digit><GeomType>" e.g. "lod2Solid", "lod1MultiSurface"
+	if (local_name.size() < 5 || local_name.substr(0, 3) != "lod") {
+		return std::nullopt;
+	}
+
+	// Extract LOD digit(s)
+	size_t pos = 3;
+	while (pos < local_name.size() && std::isdigit(local_name[pos])) {
+		pos++;
+	}
+	if (pos == 3 || pos >= local_name.size()) {
+		return std::nullopt;
+	}
+
+	std::string lod = local_name.substr(3, pos - 3);
+	std::string rest = local_name.substr(pos);
+
+	// Map the rest to a CityJSON geometry type
+	// Common CityGML 2.0 geometry property suffixes
+	if (rest == "Solid") {
+		return std::make_pair(lod, std::string("Solid"));
+	}
+	if (rest == "MultiSurface") {
+		return std::make_pair(lod, std::string("MultiSurface"));
+	}
+	if (rest == "MultiCurve") {
+		return std::make_pair(lod, std::string("MultiLineString"));
+	}
+	if (rest == "FootPrint" || rest == "RoofEdge") {
+		return std::make_pair(lod, std::string("MultiSurface"));
+	}
+	if (rest == "TerrainIntersection") {
+		return std::make_pair(lod, std::string("MultiLineString"));
+	}
+	if (rest == "MultiPoint") {
+		return std::make_pair(lod, std::string("MultiPoint"));
+	}
+	if (rest == "Geometry") {
+		// Generic geometry — type determined from actual GML content
+		return std::make_pair(lod, std::string(""));
+	}
+
+	return std::nullopt;
+}
+
+// ============================================================
+// CityObject type mapping
+// ============================================================
+
+std::optional<std::string> LocalCityGMLReader::MapCityObjectType(const std::string &local_name) {
+	// CityGML 2.0 -> CityJSON type mapping
+	// Buildings
+	if (local_name == "Building") return std::string("Building");
+	if (local_name == "BuildingPart") return std::string("BuildingPart");
+	if (local_name == "BuildingInstallation") return std::string("BuildingInstallation");
+	if (local_name == "BuildingFurniture") return std::string("BuildingFurniture");
+	if (local_name == "Room") return std::string("BuildingRoom");
+	if (local_name == "IntBuildingInstallation") return std::string("BuildingInstallation");
+	// Transportation
+	if (local_name == "Road") return std::string("Road");
+	if (local_name == "Railway") return std::string("Railway");
+	if (local_name == "Track") return std::string("Road");
+	if (local_name == "Square") return std::string("TransportSquare");
+	if (local_name == "TransportationComplex") return std::string("Road");
+	// Water
+	if (local_name == "WaterBody") return std::string("WaterBody");
+	// Vegetation
+	if (local_name == "PlantCover") return std::string("PlantCover");
+	if (local_name == "SolitaryVegetationObject") return std::string("SolitaryVegetationObject");
+	// Land use
+	if (local_name == "LandUse") return std::string("LandUse");
+	// City furniture
+	if (local_name == "CityFurniture") return std::string("CityFurniture");
+	// Relief
+	if (local_name == "ReliefFeature") return std::string("TINRelief");
+	if (local_name == "TINRelief") return std::string("TINRelief");
+	// Bridge
+	if (local_name == "Bridge") return std::string("Bridge");
+	if (local_name == "BridgePart") return std::string("BridgePart");
+	if (local_name == "BridgeInstallation") return std::string("BridgeInstallation");
+	if (local_name == "BridgeConstructionElement") return std::string("BridgeConstructiveElement");
+	// Tunnel
+	if (local_name == "Tunnel") return std::string("Tunnel");
+	if (local_name == "TunnelPart") return std::string("TunnelPart");
+	if (local_name == "TunnelInstallation") return std::string("TunnelInstallation");
+	// Generics
+	if (local_name == "GenericCityObject") return std::string("GenericCityObject");
+	// CityObjectGroup
+	if (local_name == "CityObjectGroup") return std::string("CityObjectGroup");
+
+	return std::nullopt;
+}
+
+// ============================================================
+// GML Geometry Parsing
+// ============================================================
+
+json LocalCityGMLReader::ParseLinearRing(const pugi::xml_node &ring_node,
+                                         std::vector<std::array<double, 3>> &vertex_pool,
+                                         std::unordered_map<std::string, uint32_t> &vertex_index) const {
+	json indices = json::array();
+
+	// Look for <gml:posList> child
+	for (auto child : ring_node.children()) {
+		std::string ln = LocalName(child.name());
+		if (ln == "posList") {
+			int dim = child.attribute("srsDimension").as_int(3);
+			auto coords = ParsePosList(child.child_value(), dim);
+			for (const auto &c : coords) {
+				indices.push_back(AddVertex(c[0], c[1], c[2], vertex_pool, vertex_index));
+			}
+			break;
+		}
+		if (ln == "pos") {
+			auto coords = ParsePosList(child.child_value(), 3);
+			if (!coords.empty()) {
+				indices.push_back(AddVertex(coords[0][0], coords[0][1], coords[0][2], vertex_pool, vertex_index));
+			}
+		}
+		if (ln == "coordinates") {
+			// Comma-separated format: "x1,y1,z1 x2,y2,z2 ..."
+			std::string text = child.child_value();
+			std::replace(text.begin(), text.end(), ',', ' ');
+			auto coords = ParsePosList(text, 3);
+			for (const auto &c : coords) {
+				indices.push_back(AddVertex(c[0], c[1], c[2], vertex_pool, vertex_index));
+			}
+			break;
+		}
+	}
+
+	// Remove closing vertex if it duplicates the first (CityJSON convention: rings are not closed)
+	if (indices.size() > 1 && indices.front() == indices.back()) {
+		indices.erase(indices.end() - 1);
+	}
+
+	return indices;
+}
+
+json LocalCityGMLReader::ParsePolygon(const pugi::xml_node &polygon_node,
+                                      std::vector<std::array<double, 3>> &vertex_pool,
+                                      std::unordered_map<std::string, uint32_t> &vertex_index) const {
+	// CityJSON polygon boundaries = [[exterior_ring], [hole1], [hole2], ...]
+	// Exterior ring MUST come first — collect separately to guarantee ordering
+	json exterior_ring;
+	json interior_rings = json::array();
+
+	for (auto child : polygon_node.children()) {
+		std::string ln = LocalName(child.name());
+		if (ln != "exterior" && ln != "interior") {
+			continue;
+		}
+		for (auto ring_child : child.children()) {
+			if (LocalName(ring_child.name()) == "LinearRing") {
+				if (ln == "exterior") {
+					exterior_ring = ParseLinearRing(ring_child, vertex_pool, vertex_index);
+				} else {
+					interior_rings.push_back(ParseLinearRing(ring_child, vertex_pool, vertex_index));
+				}
+				break;
+			}
+		}
+	}
+
+	json rings = json::array();
+	if (!exterior_ring.is_null()) {
+		rings.push_back(std::move(exterior_ring));
+		for (auto &r : interior_rings) {
+			rings.push_back(std::move(r));
+		}
+	}
+	return rings;
+}
+
+json LocalCityGMLReader::ParseShell(const pugi::xml_node &shell_node,
+                                    std::vector<std::array<double, 3>> &vertex_pool,
+                                    std::unordered_map<std::string, uint32_t> &vertex_index) const {
+	// A shell = array of polygons (surfaces)
+	json surfaces = json::array();
+
+	for (auto child : shell_node.children()) {
+		std::string ln = LocalName(child.name());
+		if (ln == "surfaceMember") {
+			// Find the Polygon inside
+			for (auto poly_child : child.children()) {
+				std::string pln = LocalName(poly_child.name());
+				if (pln == "Polygon") {
+					surfaces.push_back(ParsePolygon(poly_child, vertex_pool, vertex_index));
+				} else if (pln == "CompositeSurface") {
+					// Flatten composite surface members into the shell
+					auto cs = ParseCompositeSurface(poly_child, vertex_pool, vertex_index);
+					for (auto &surf : cs) {
+						surfaces.push_back(std::move(surf));
+					}
+				}
+			}
+		}
+	}
+
+	return surfaces;
+}
+
+json LocalCityGMLReader::ParseSolid(const pugi::xml_node &solid_node,
+                                    std::vector<std::array<double, 3>> &vertex_pool,
+                                    std::unordered_map<std::string, uint32_t> &vertex_index) const {
+	// CityJSON Solid boundaries = [exterior_shell, interior_shell1, ...]
+	// Each shell = array of polygon surfaces
+	json shells = json::array();
+
+	for (auto child : solid_node.children()) {
+		std::string ln = LocalName(child.name());
+		if (ln == "exterior" || ln == "interior") {
+			// Find Shell/CompositeSurface inside
+			for (auto shell_child : child.children()) {
+				std::string sln = LocalName(shell_child.name());
+				if (sln == "Shell" || sln == "CompositeSurface") {
+					shells.push_back(ParseShell(shell_child, vertex_pool, vertex_index));
+				}
+			}
+		}
+	}
+
+	return shells;
+}
+
+json LocalCityGMLReader::ParseMultiSurface(const pugi::xml_node &ms_node,
+                                           std::vector<std::array<double, 3>> &vertex_pool,
+                                           std::unordered_map<std::string, uint32_t> &vertex_index) const {
+	// CityJSON MultiSurface boundaries = [polygon1, polygon2, ...]
+	json surfaces = json::array();
+
+	for (auto child : ms_node.children()) {
+		std::string ln = LocalName(child.name());
+		if (ln == "surfaceMember") {
+			for (auto poly_child : child.children()) {
+				std::string pln = LocalName(poly_child.name());
+				if (pln == "Polygon") {
+					surfaces.push_back(ParsePolygon(poly_child, vertex_pool, vertex_index));
+				} else if (pln == "OrientableSurface") {
+					// Look for baseSurface -> Polygon
+					for (auto base : poly_child.children()) {
+						if (LocalName(base.name()) == "baseSurface") {
+							for (auto bp : base.children()) {
+								if (LocalName(bp.name()) == "Polygon") {
+									surfaces.push_back(ParsePolygon(bp, vertex_pool, vertex_index));
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return surfaces;
+}
+
+json LocalCityGMLReader::ParseCompositeSurface(const pugi::xml_node &cs_node,
+                                               std::vector<std::array<double, 3>> &vertex_pool,
+                                               std::unordered_map<std::string, uint32_t> &vertex_index) const {
+	// Same structure as MultiSurface for CityJSON purposes
+	return ParseMultiSurface(cs_node, vertex_pool, vertex_index);
+}
+
+json LocalCityGMLReader::ParseMultiSolid(const pugi::xml_node &ms_node,
+                                         std::vector<std::array<double, 3>> &vertex_pool,
+                                         std::unordered_map<std::string, uint32_t> &vertex_index) const {
+	// CityJSON MultiSolid/CompositeSolid boundaries = [solid1, solid2, ...]
+	json solids = json::array();
+
+	for (auto child : ms_node.children()) {
+		std::string ln = LocalName(child.name());
+		if (ln == "solidMember") {
+			for (auto solid_child : child.children()) {
+				if (LocalName(solid_child.name()) == "Solid") {
+					solids.push_back(ParseSolid(solid_child, vertex_pool, vertex_index));
+				}
+			}
+		}
+	}
+
+	return solids;
+}
+
+// ============================================================
+// Geometry property parsing
+// ============================================================
+
+std::optional<Geometry> LocalCityGMLReader::ParseGeometryProperty(
+    const pugi::xml_node &prop_node, const std::string &lod, const std::string &geom_type,
+    std::vector<std::array<double, 3>> &vertex_pool,
+    std::unordered_map<std::string, uint32_t> &vertex_index) const {
+
+	// Find the actual GML geometry element inside the property
+	for (auto child : prop_node.children()) {
+		std::string ln = LocalName(child.name());
+		std::string actual_type = geom_type;
+
+		json boundaries;
+
+		if (ln == "Solid") {
+			boundaries = ParseSolid(child, vertex_pool, vertex_index);
+			actual_type = "Solid";
+		} else if (ln == "MultiSurface") {
+			boundaries = ParseMultiSurface(child, vertex_pool, vertex_index);
+			actual_type = "MultiSurface";
+		} else if (ln == "CompositeSurface") {
+			boundaries = ParseCompositeSurface(child, vertex_pool, vertex_index);
+			actual_type = "CompositeSurface";
+		} else if (ln == "MultiSolid" || ln == "CompositeSolid") {
+			boundaries = ParseMultiSolid(child, vertex_pool, vertex_index);
+			actual_type = (ln == "MultiSolid") ? "MultiSolid" : "CompositeSolid";
+		} else if (ln == "MultiCurve") {
+			// MultiCurve -> MultiLineString
+			json lines = json::array();
+			for (auto member : child.children()) {
+				if (LocalName(member.name()) == "curveMember") {
+					for (auto curve : member.children()) {
+						if (LocalName(curve.name()) == "LineString") {
+							json line_indices = json::array();
+							for (auto pos_child : curve.children()) {
+								std::string pln = LocalName(pos_child.name());
+								if (pln == "posList") {
+									int dim = pos_child.attribute("srsDimension").as_int(3);
+									auto coords = ParsePosList(pos_child.child_value(), dim);
+									for (const auto &c : coords) {
+										line_indices.push_back(
+										    AddVertex(c[0], c[1], c[2], vertex_pool, vertex_index));
+									}
+								}
+							}
+							lines.push_back(line_indices);
+						}
+					}
+				}
+			}
+			boundaries = lines;
+			actual_type = "MultiLineString";
+		} else if (ln == "Polygon") {
+			// Single polygon wrapped as MultiSurface
+			boundaries = json::array();
+			boundaries.push_back(ParsePolygon(child, vertex_pool, vertex_index));
+			actual_type = "MultiSurface";
+		} else if (ln == "TriangulatedSurface" || ln == "TIN") {
+			// TIN as CompositeSurface
+			boundaries = json::array();
+			// Look for trianglePatches/Triangle
+			for (auto patches : child.children()) {
+				std::string patches_ln = LocalName(patches.name());
+				if (patches_ln == "trianglePatches" || patches_ln == "patches") {
+					for (auto triangle : patches.children()) {
+						if (LocalName(triangle.name()) == "Triangle") {
+							// Triangle has exterior -> LinearRing
+							for (auto ext : triangle.children()) {
+								if (LocalName(ext.name()) == "exterior") {
+									for (auto ring : ext.children()) {
+										if (LocalName(ring.name()) == "LinearRing") {
+											json tri_rings = json::array();
+											tri_rings.push_back(
+											    ParseLinearRing(ring, vertex_pool, vertex_index));
+											boundaries.push_back(tri_rings);
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			actual_type = "CompositeSurface";
+		} else {
+			// Unknown geometry type, skip
+			continue;
+		}
+
+		if (!boundaries.empty()) {
+			return Geometry(actual_type, lod, std::move(boundaries));
+		}
+	}
+
+	return std::nullopt;
+}
+
+// ============================================================
+// Attribute parsing
+// ============================================================
+
+// Known CityGML 2.0 geometry property tag suffixes to skip during attribute extraction
+static bool IsGeometryTag(const std::string &local_name) {
+	if (local_name.size() >= 4 && local_name.substr(0, 3) == "lod") {
+		return true;
+	}
+	// Other non-attribute elements
+	static const std::vector<std::string> skip_tags = {
+	    "boundedBy",        "consistsOfBuildingPart",
+	    "outerBuildingInstallation", "interiorBuildingInstallation",
+	    "interiorRoom",     "opening",
+	    "address",          "genericApplicationPropertyOf",
+	    "appearanceMember", "appearance",
+	    "cityObjectMember", "consistsOf",
+	    "trafficArea",      "auxiliaryTrafficArea",
+	    "interiorFurniture", "roomInstallation",
+	};
+	for (const auto &tag : skip_tags) {
+		if (local_name == tag) {
+			return true;
+		}
+	}
+	return false;
+}
+
+std::map<std::string, json> LocalCityGMLReader::ParseAttributes(const pugi::xml_node &obj_node) {
+	std::map<std::string, json> attributes;
+
+	for (auto child : obj_node.children()) {
+		if (child.type() != pugi::node_element) {
+			continue;
+		}
+		std::string ln = LocalName(child.name());
+
+		// Skip geometry and structural elements
+		if (IsGeometryTag(ln)) {
+			continue;
+		}
+
+		// Skip elements that contain child CityObjects
+		if (MapCityObjectType(ln).has_value()) {
+			continue;
+		}
+
+		// Get text content
+		std::string text = child.child_value();
+		if (text.empty()) {
+			// Check for nested text in child elements (complex attributes)
+			// For now, skip complex nested attributes
+			continue;
+		}
+
+		// Try to infer the value type
+		// Try integer
+		try {
+			size_t pos;
+			long long int_val = std::stoll(text, &pos);
+			if (pos == text.size()) {
+				attributes[ln] = int_val;
+				continue;
+			}
+		} catch (...) {
+		}
+
+		// Try double
+		try {
+			size_t pos;
+			double dbl_val = std::stod(text, &pos);
+			if (pos == text.size()) {
+				attributes[ln] = dbl_val;
+				continue;
+			}
+		} catch (...) {
+		}
+
+		// Try boolean
+		if (text == "true" || text == "false") {
+			attributes[ln] = (text == "true");
+			continue;
+		}
+
+		// Default: string
+		attributes[ln] = text;
+	}
+
+	return attributes;
+}
+
+// ============================================================
+// CityObject node parsing
+// ============================================================
+
+CityJSONFeature LocalCityGMLReader::ParseCityObjectNode(const pugi::xml_node &obj_node) const {
+	std::string local_name = LocalName(obj_node.name());
+	auto type_opt = MapCityObjectType(local_name);
+	if (!type_opt.has_value()) {
+		throw CityJSONError::InvalidSchema("Unknown CityGML object type: " + local_name, file_path_);
+	}
+
+	// Get gml:id
+	std::string gml_id = obj_node.attribute("gml:id").as_string("");
+	if (gml_id.empty()) {
+		gml_id = obj_node.attribute("id").as_string("");
+	}
+	if (gml_id.empty()) {
+		gml_id = "citygml_obj_" + std::to_string(id_counter_++);
+	}
+
+	CityJSONFeature feature(gml_id);
+
+	// Per-feature vertex pool
+	std::vector<std::array<double, 3>> vertex_pool;
+	std::unordered_map<std::string, uint32_t> vertex_index;
+
+	// Create the root CityObject
+	CityObject city_object(type_opt.value());
+	city_object.attributes = ParseAttributes(obj_node);
+
+	// Parse geometry properties
+	for (auto child : obj_node.children()) {
+		if (child.type() != pugi::node_element) {
+			continue;
+		}
+		std::string child_ln = LocalName(child.name());
+		auto lod_info = ParseLODTag(child_ln);
+		if (lod_info.has_value()) {
+			auto geom = ParseGeometryProperty(child, lod_info->first, lod_info->second, vertex_pool, vertex_index);
+			if (geom.has_value()) {
+				city_object.geometry.push_back(std::move(geom.value()));
+			}
+		}
+	}
+
+	// Parse child CityObjects (e.g. BuildingPart inside Building)
+	// CityGML 2.0 nests children inside structural elements like <bldg:consistsOfBuildingPart>
+	for (auto child : obj_node.children()) {
+		if (child.type() != pugi::node_element) {
+			continue;
+		}
+		std::string child_ln = LocalName(child.name());
+
+		// Look for elements that contain nested CityObjects
+		for (auto nested : child.children()) {
+			if (nested.type() != pugi::node_element) {
+				continue;
+			}
+			std::string nested_ln = LocalName(nested.name());
+			auto nested_type = MapCityObjectType(nested_ln);
+			if (nested_type.has_value()) {
+				// This is a child CityObject
+				std::string child_id = nested.attribute("gml:id").as_string("");
+				if (child_id.empty()) {
+					child_id = nested.attribute("id").as_string("");
+				}
+				if (child_id.empty()) {
+					child_id = gml_id + "_child_" + std::to_string(id_counter_++);
+				}
+
+				CityObject child_obj(nested_type.value());
+				child_obj.attributes = ParseAttributes(nested);
+				child_obj.parents.push_back(gml_id);
+
+				// Parse child geometry (shares the same vertex pool)
+				for (auto geom_child : nested.children()) {
+					if (geom_child.type() != pugi::node_element) {
+						continue;
+					}
+					std::string gcl = LocalName(geom_child.name());
+					auto child_lod_info = ParseLODTag(gcl);
+					if (child_lod_info.has_value()) {
+						auto geom = ParseGeometryProperty(geom_child, child_lod_info->first,
+						                                  child_lod_info->second, vertex_pool, vertex_index);
+						if (geom.has_value()) {
+							child_obj.geometry.push_back(std::move(geom.value()));
+						}
+					}
+				}
+
+				city_object.children.push_back(child_id);
+				feature.city_objects[child_id] = std::move(child_obj);
+			}
+		}
+	}
+
+	feature.city_objects[gml_id] = std::move(city_object);
+	feature.vertices = std::move(vertex_pool);
+
+	return feature;
+}
+
+// ============================================================
+// Find cityObjectMember nodes
+// ============================================================
+
+std::vector<pugi::xml_node> LocalCityGMLReader::FindCityObjectMembers(const pugi::xml_node &root) {
+	std::vector<pugi::xml_node> members;
+
+	for (auto child : root.children()) {
+		std::string ln = LocalName(child.name());
+		if (ln == "cityObjectMember" || ln == "featureMember") {
+			// The actual CityObject is the first element child
+			for (auto obj : child.children()) {
+				if (obj.type() == pugi::node_element) {
+					members.push_back(obj);
+					break;
+				}
+			}
+		}
+	}
+
+	return members;
+}
+
+// ============================================================
+// ReadMetadata
+// ============================================================
+
+CityJSON LocalCityGMLReader::ReadMetadata() const {
+	if (cached_metadata_.has_value()) {
+		return cached_metadata_.value();
+	}
+
+	auto doc = LoadXML();
+	auto root = doc.first_child();
+
+	CityJSON metadata;
+	metadata.version = "CityGML2.0";
+	metadata.transform = std::nullopt; // No transform — real-world coordinates
+
+	// Extract srsName from root or Envelope
+	std::string srs_name;
+	auto root_srs = root.attribute("srsName");
+	if (root_srs) {
+		srs_name = root_srs.as_string();
+	}
+
+	// Look for gml:boundedBy -> gml:Envelope
+	for (auto child : root.children()) {
+		std::string ln = LocalName(child.name());
+		if (ln == "boundedBy") {
+			for (auto env_child : child.children()) {
+				if (LocalName(env_child.name()) == "Envelope") {
+					if (srs_name.empty()) {
+						auto env_srs = env_child.attribute("srsName");
+						if (env_srs) {
+							srs_name = env_srs.as_string();
+						}
+					}
+
+					// Parse extent
+					Metadata meta;
+					std::string lower_corner, upper_corner;
+					for (auto corner : env_child.children()) {
+						std::string cln = LocalName(corner.name());
+						if (cln == "lowerCorner") {
+							lower_corner = corner.child_value();
+						} else if (cln == "upperCorner") {
+							upper_corner = corner.child_value();
+						}
+					}
+
+					if (!lower_corner.empty() && !upper_corner.empty()) {
+						auto lc = ParsePosList(lower_corner);
+						auto uc = ParsePosList(upper_corner);
+						if (!lc.empty() && !uc.empty()) {
+							meta.geographic_extent = GeographicalExtent(lc[0][0], lc[0][1], lc[0][2], uc[0][0],
+							                                            uc[0][1], uc[0][2]);
+						}
+					}
+
+					metadata.metadata = meta;
+				}
+			}
+		}
+
+		// Extract gml:name as title
+		if (ln == "name") {
+			if (!metadata.metadata.has_value()) {
+				metadata.metadata = Metadata();
+			}
+			metadata.metadata->title = child.child_value();
+		}
+	}
+
+	if (!srs_name.empty()) {
+		metadata.crs = ParseSrsName(srs_name);
+	}
+
+	cached_metadata_ = metadata;
+	return metadata;
+}
+
+// ============================================================
+// ReadNFeatures
+// ============================================================
+
+std::vector<CityJSONFeature> LocalCityGMLReader::ReadNFeatures(size_t n) const {
+	auto doc = LoadXML();
+	auto root = doc.first_child();
+	auto members = FindCityObjectMembers(root);
+
+	std::vector<CityJSONFeature> features;
+	size_t count = 0;
+
+	for (const auto &obj_node : members) {
+		if (count >= n) {
+			break;
+		}
+		std::string ln = LocalName(obj_node.name());
+		if (MapCityObjectType(ln).has_value()) {
+			features.push_back(ParseCityObjectNode(obj_node));
+			count++;
+		}
+	}
+
+	return features;
+}
+
+// ============================================================
+// ReadAllChunks
+// ============================================================
+
+CityJSONFeatureChunk LocalCityGMLReader::ReadAllChunks() const {
+	auto doc = LoadXML();
+	auto root = doc.first_child();
+	auto members = FindCityObjectMembers(root);
+
+	std::vector<CityJSONFeature> features;
+
+	for (const auto &obj_node : members) {
+		std::string ln = LocalName(obj_node.name());
+		if (MapCityObjectType(ln).has_value()) {
+			features.push_back(ParseCityObjectNode(obj_node));
+		}
+	}
+
+	return CityJSONFeatureChunk::CreateChunks(std::move(features), STANDARD_VECTOR_SIZE);
+}
+
+// ============================================================
+// ReadNthChunk
+// ============================================================
+
+CityJSONFeatureChunk LocalCityGMLReader::ReadNthChunk(size_t n) const {
+	CityJSONFeatureChunk all_chunks = ReadAllChunks();
+
+	if (n >= all_chunks.ChunkCount()) {
+		return CityJSONFeatureChunk();
+	}
+
+	auto chunk_opt = all_chunks.GetChunk(n);
+	if (!chunk_opt.has_value()) {
+		return CityJSONFeatureChunk();
+	}
+
+	CityJSONFeatureChunk result;
+	result.records = std::vector<CityJSONFeature>(chunk_opt->begin(), chunk_opt->end());
+	result.chunks = {Range(0, result.records.size())};
+	return result;
+}
+
+// ============================================================
+// Columns
+// ============================================================
+
+std::vector<Column> LocalCityGMLReader::Columns() const {
+	if (cached_columns_.has_value()) {
+		return cached_columns_.value();
+	}
+
+	std::vector<Column> columns = GetDefinedColumns();
+
+	std::vector<CityJSONFeature> sample_features = ReadNFeatures(sample_lines_);
+
+	std::vector<Column> attr_columns = CityObjectUtils::InferAttributeColumns(sample_features, sample_lines_);
+	std::vector<Column> geom_columns = CityObjectUtils::InferGeometryColumns(sample_features, sample_lines_);
+
+	columns.insert(columns.end(), attr_columns.begin(), attr_columns.end());
+	columns.insert(columns.end(), geom_columns.begin(), geom_columns.end());
+
+	cached_columns_ = columns;
+	return columns;
+}
+
+} // namespace cityjson
+} // namespace duckdb

--- a/src/cityjson/column_types.cpp
+++ b/src/cityjson/column_types.cpp
@@ -373,18 +373,21 @@ bool IsPredefinedColumn(const std::string &name) {
 }
 
 bool IsGeometryColumn(const std::string &name) {
-	// Pattern: geom_lod{X}_{Y}
-	std::regex geom_pattern(R"(geom_lod\d+_\d+)");
+	// Pattern: geom_lod{X} or geom_lod{X}_{Y}
+	std::regex geom_pattern(R"(geom_lod\d+(_\d+)?)");
 	return std::regex_match(name, geom_pattern);
 }
 
 std::string ParseLODFromColumnName(const std::string &column_name) {
-	// Parse "geom_lod2_1" -> "2.1"
-	std::regex lod_pattern(R"(geom_lod(\d+)_(\d+))");
+	// Parse "geom_lod2_1" -> "2.1" or "geom_lod2" -> "2"
+	std::regex lod_pattern(R"(geom_lod(\d+)(?:_(\d+))?)");
 	std::smatch match;
 
 	if (std::regex_match(column_name, match, lod_pattern)) {
-		return match[1].str() + "." + match[2].str();
+		if (match[2].matched) {
+			return match[1].str() + "." + match[2].str();
+		}
+		return match[1].str();
 	}
 
 	throw CityJSONError::InvalidSchema("Invalid geometry column name: " + column_name);

--- a/src/cityjson/metadata_table_function.cpp
+++ b/src/cityjson/metadata_table_function.cpp
@@ -1,6 +1,7 @@
 #include "cityjson/metadata_table_function.hpp"
 #include "cityjson/metadata_table.hpp"
 #include "cityjson/reader.hpp"
+#include "cityjson/citygml_reader.hpp"
 #include "cityjson/json_utils.hpp"
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 
@@ -177,6 +178,59 @@ TableFunction CreateCityJSONSeqMetadataTableFunction() {
 
 void RegisterCityJSONSeqMetadataTableFunction(ExtensionLoader &loader) {
 	auto func = CreateCityJSONSeqMetadataTableFunction();
+	loader.RegisterFunction(func);
+}
+
+// Bind function for citygml_metadata — always uses LocalCityGMLReader
+static unique_ptr<FunctionData> CityGMLMetadataBind(ClientContext &context, TableFunctionBindInput &input,
+                                                    vector<LogicalType> &return_types, vector<string> &names) {
+	auto result = make_uniq<MetadataBindData>();
+
+	result->file_name = StringValue::Get(input.inputs[0]);
+
+	std::unique_ptr<CityJSONReader> reader;
+	try {
+		std::string content = json_utils::ReadFileContent(context, result->file_name);
+		reader = std::make_unique<LocalCityGMLReader>(result->file_name, std::move(content), 100);
+	} catch (const CityJSONError &e) {
+		throw BinderException("Failed to open CityGML file: " + std::string(e.what()));
+	}
+
+	try {
+		result->metadata = reader->ReadMetadata();
+	} catch (const CityJSONError &e) {
+		throw BinderException("Failed to read CityGML metadata: " + std::string(e.what()));
+	}
+
+	result->city_objects_count = 0;
+	try {
+		auto chunks = reader->ReadAllChunks();
+		for (size_t i = 0; i < chunks.ChunkCount(); i++) {
+			auto chunk = chunks.GetChunk(i);
+			if (chunk) {
+				for (const auto &feature : *chunk) {
+					result->city_objects_count += feature.city_objects.size();
+				}
+			}
+		}
+	} catch (const CityJSONError &e) {
+		result->city_objects_count = 0;
+	}
+
+	return_types = MetadataTableUtils::GetMetadataTableTypes();
+	names = MetadataTableUtils::GetMetadataTableNames();
+
+	return std::move(result);
+}
+
+TableFunction CreateCityGMLMetadataTableFunction() {
+	TableFunction func("citygml_metadata", {LogicalType::VARCHAR}, MetadataScan, CityGMLMetadataBind);
+	func.init_global = MetadataInitGlobal;
+	return func;
+}
+
+void RegisterCityGMLMetadataTableFunction(ExtensionLoader &loader) {
+	auto func = CreateCityGMLMetadataTableFunction();
 	loader.RegisterFunction(func);
 }
 

--- a/src/cityjson/reader_factory.cpp
+++ b/src/cityjson/reader_factory.cpp
@@ -1,4 +1,5 @@
 #include "cityjson/reader.hpp"
+#include "cityjson/citygml_reader.hpp"
 #include "cityjson/json_utils.hpp"
 #ifdef CITYJSON_HAS_FCB
 #include "cityjson/flatcitybuf_reader.hpp"
@@ -82,6 +83,11 @@ std::unique_ptr<CityJSONReader> OpenAnyCityJSONFile(const std::string &file_name
 	}
 	test_file.close();
 
+	// CityGML format
+	if (EndsWith(file_name, ".gml") || EndsWith(file_name, ".citygml")) {
+		return std::make_unique<LocalCityGMLReader>(file_name, DEFAULT_SAMPLE_LINES);
+	}
+
 	// Try to detect format from extension first
 	if (EndsWith(file_name, ".city.jsonl") || EndsWith(file_name, ".jsonl")) {
 		// CityJSONSeq format
@@ -116,6 +122,11 @@ std::unique_ptr<CityJSONReader> OpenAnyCityJSONFile(duckdb::ClientContext &conte
 		return std::make_unique<FlatCityBufReader>(file_name, file_name, DEFAULT_SAMPLE_LINES);
 	}
 #endif
+
+	// CityGML format
+	if (EndsWith(file_name, ".gml") || EndsWith(file_name, ".citygml")) {
+		return std::make_unique<LocalCityGMLReader>(file_name, std::move(content), DEFAULT_SAMPLE_LINES);
+	}
 
 	// Try to detect format from extension first
 	if (EndsWith(file_name, ".city.jsonl") || EndsWith(file_name, ".jsonl")) {

--- a/src/cityjson/table_function_registration.cpp
+++ b/src/cityjson/table_function_registration.cpp
@@ -53,5 +53,29 @@ void RegisterCityJSONSeqTableFunction(ExtensionLoader &loader) {
 	loader.RegisterFunction(func);
 }
 
+TableFunction CreateReadCityGMLTableFunction() {
+	TableFunction func("read_citygml", {LogicalType::VARCHAR}, CityJSONScan, CityJSONBind);
+
+	// Named parameters (same as read_cityjson)
+	func.named_parameters["sample_lines"] = LogicalType::BIGINT;
+	func.named_parameters["lod"] = LogicalType::VARCHAR;
+
+	// Set callbacks (reuse same stateless callbacks)
+	func.init_global = CityJSONInitGlobal;
+	func.init_local = CityJSONInitLocal;
+	func.cardinality = CityJSONCardinality;
+	func.statistics = CityJSONStatistics;
+
+	// Enable projection pushdown
+	func.projection_pushdown = true;
+
+	return func;
+}
+
+void RegisterCityGMLTableFunction(ExtensionLoader &loader) {
+	auto func = CreateReadCityGMLTableFunction();
+	loader.RegisterFunction(func);
+}
+
 } // namespace cityjson
 } // namespace duckdb

--- a/src/cityjson_extension.cpp
+++ b/src/cityjson_extension.cpp
@@ -25,6 +25,12 @@ static void LoadInternal(ExtensionLoader &loader) {
 	// Register the cityjsonseq_metadata table function (dedicated CityJSONSeq metadata reader)
 	cityjson::RegisterCityJSONSeqMetadataTableFunction(loader);
 
+	// Register the read_citygml table function
+	cityjson::RegisterCityGMLTableFunction(loader);
+
+	// Register the citygml_metadata table function
+	cityjson::RegisterCityGMLMetadataTableFunction(loader);
+
 	// Register COPY TO functions (cityjson and cityjsonseq formats)
 	cityjson::RegisterCityJSONCopyFunction(loader);
 	cityjson::RegisterCityJSONSeqCopyFunction(loader);

--- a/src/include/cityjson/citygml_reader.hpp
+++ b/src/include/cityjson/citygml_reader.hpp
@@ -1,0 +1,91 @@
+#pragma once
+
+#include "cityjson/reader.hpp"
+#include <pugixml.hpp>
+#include <unordered_map>
+
+namespace duckdb {
+namespace cityjson {
+
+/**
+ * Reader for CityGML 2.0 format (.gml, .citygml)
+ * Parses XML/GML and maps to the CityJSON internal data model.
+ * Each top-level CityObject becomes a CityJSONFeature with its own vertex pool.
+ */
+class LocalCityGMLReader : public CityJSONReader {
+public:
+	explicit LocalCityGMLReader(const std::string &file_path, size_t sample_lines = 100);
+	LocalCityGMLReader(const std::string &name, std::string content, size_t sample_lines);
+
+	std::string Name() const override;
+	CityJSON ReadMetadata() const override;
+	CityJSONFeatureChunk ReadNthChunk(size_t n) const override;
+	CityJSONFeatureChunk ReadAllChunks() const override;
+	std::vector<CityJSONFeature> ReadNFeatures(size_t n) const override;
+	std::vector<Column> Columns() const override;
+
+private:
+	std::string file_path_;
+	size_t sample_lines_;
+	std::optional<std::string> content_;
+
+	mutable std::optional<CityJSON> cached_metadata_;
+	mutable std::optional<std::vector<Column>> cached_columns_;
+	mutable int id_counter_ = 0; // Synthetic ID counter for objects missing gml:id
+
+	// Load and parse the XML document
+	pugi::xml_document LoadXML() const;
+
+	// Extract the local name from a possibly namespaced tag (e.g. "bldg:Building" -> "Building")
+	static std::string LocalName(const char *name);
+
+	// Parse CRS from srsName attribute (e.g. "urn:ogc:def:crs:EPSG::7415" or "EPSG:7415")
+	static std::optional<CRS> ParseSrsName(const std::string &srs);
+
+	// Vertex deduplication helper: returns index into vertex_pool, inserting if new
+	static uint32_t AddVertex(double x, double y, double z, std::vector<std::array<double, 3>> &vertex_pool,
+	                          std::unordered_map<std::string, uint32_t> &vertex_index);
+
+	// Coordinate parsing
+	static std::vector<std::array<double, 3>> ParsePosList(const std::string &text, int srs_dimension = 3);
+
+	// GML geometry parsing — all return boundary JSON arrays with vertex indices
+	json ParseLinearRing(const pugi::xml_node &ring_node, std::vector<std::array<double, 3>> &vertex_pool,
+	                     std::unordered_map<std::string, uint32_t> &vertex_index) const;
+	json ParsePolygon(const pugi::xml_node &polygon_node, std::vector<std::array<double, 3>> &vertex_pool,
+	                  std::unordered_map<std::string, uint32_t> &vertex_index) const;
+	json ParseMultiSurface(const pugi::xml_node &ms_node, std::vector<std::array<double, 3>> &vertex_pool,
+	                       std::unordered_map<std::string, uint32_t> &vertex_index) const;
+	json ParseCompositeSurface(const pugi::xml_node &cs_node, std::vector<std::array<double, 3>> &vertex_pool,
+	                           std::unordered_map<std::string, uint32_t> &vertex_index) const;
+	json ParseSolid(const pugi::xml_node &solid_node, std::vector<std::array<double, 3>> &vertex_pool,
+	                std::unordered_map<std::string, uint32_t> &vertex_index) const;
+	json ParseShell(const pugi::xml_node &shell_node, std::vector<std::array<double, 3>> &vertex_pool,
+	                std::unordered_map<std::string, uint32_t> &vertex_index) const;
+	json ParseMultiSolid(const pugi::xml_node &ms_node, std::vector<std::array<double, 3>> &vertex_pool,
+	                     std::unordered_map<std::string, uint32_t> &vertex_index) const;
+
+	// Parse a CityGML geometry property element (e.g. <bldg:lod2Solid>)
+	std::optional<Geometry> ParseGeometryProperty(const pugi::xml_node &prop_node, const std::string &lod,
+	                                              const std::string &geom_type,
+	                                              std::vector<std::array<double, 3>> &vertex_pool,
+	                                              std::unordered_map<std::string, uint32_t> &vertex_index) const;
+
+	// Parse LOD tag name (e.g. "lod2Solid" -> {"2", "Solid"})
+	static std::optional<std::pair<std::string, std::string>> ParseLODTag(const std::string &local_name);
+
+	// Map CityGML element local names to CityJSON type strings
+	static std::optional<std::string> MapCityObjectType(const std::string &local_name);
+
+	// Parse attributes from a CityObject element
+	static std::map<std::string, json> ParseAttributes(const pugi::xml_node &obj_node);
+
+	// Parse a top-level CityObject node into a CityJSONFeature
+	CityJSONFeature ParseCityObjectNode(const pugi::xml_node &obj_node) const;
+
+	// Find all top-level cityObjectMember nodes
+	static std::vector<pugi::xml_node> FindCityObjectMembers(const pugi::xml_node &root);
+};
+
+} // namespace cityjson
+} // namespace duckdb

--- a/src/include/cityjson/metadata_table_function.hpp
+++ b/src/include/cityjson/metadata_table_function.hpp
@@ -27,5 +27,16 @@ TableFunction CreateCityJSONSeqMetadataTableFunction();
  */
 void RegisterCityJSONSeqMetadataTableFunction(ExtensionLoader &loader);
 
+/**
+ * Create the citygml_metadata table function
+ * Always reads metadata from a CityGML (.gml) file
+ */
+TableFunction CreateCityGMLMetadataTableFunction();
+
+/**
+ * Register the citygml_metadata table function
+ */
+void RegisterCityGMLMetadataTableFunction(ExtensionLoader &loader);
+
 } // namespace cityjson
 } // namespace duckdb

--- a/src/include/cityjson/table_function.hpp
+++ b/src/include/cityjson/table_function.hpp
@@ -140,5 +140,16 @@ TableFunction CreateReadCityJSONSeqTableFunction();
  */
 void RegisterCityJSONSeqTableFunction(ExtensionLoader &loader);
 
+/**
+ * Create read_citygml table function
+ * Reads CityGML 2.0/3.0 files and maps to CityJSON data model
+ */
+TableFunction CreateReadCityGMLTableFunction();
+
+/**
+ * Register read_citygml function with database
+ */
+void RegisterCityGMLTableFunction(ExtensionLoader &loader);
+
 } // namespace cityjson
 } // namespace duckdb

--- a/test/data/minimal.gml
+++ b/test/data/minimal.gml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CityModel xmlns="http://www.opengis.net/citygml/2.0"
+           xmlns:gml="http://www.opengis.net/gml"
+           xmlns:bldg="http://www.opengis.net/citygml/building/2.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           gml:id="cm1">
+  <gml:name>Minimal CityGML Test</gml:name>
+  <gml:boundedBy>
+    <gml:Envelope srsName="EPSG:7415" srsDimension="3">
+      <gml:lowerCorner>0.0 0.0 0.0</gml:lowerCorner>
+      <gml:upperCorner>10.0 10.0 15.5</gml:upperCorner>
+    </gml:Envelope>
+  </gml:boundedBy>
+  <cityObjectMember>
+    <bldg:Building gml:id="building1">
+      <bldg:yearOfConstruction>2020</bldg:yearOfConstruction>
+      <bldg:measuredHeight uom="m">15.5</bldg:measuredHeight>
+      <bldg:function>residential</bldg:function>
+      <bldg:lod2Solid>
+        <gml:Solid>
+          <gml:exterior>
+            <gml:CompositeSurface>
+              <gml:surfaceMember>
+                <gml:Polygon>
+                  <gml:exterior>
+                    <gml:LinearRing>
+                      <gml:posList>0.0 0.0 0.0 10.0 0.0 0.0 10.0 10.0 0.0 0.0 10.0 0.0 0.0 0.0 0.0</gml:posList>
+                    </gml:LinearRing>
+                  </gml:exterior>
+                </gml:Polygon>
+              </gml:surfaceMember>
+              <gml:surfaceMember>
+                <gml:Polygon>
+                  <gml:exterior>
+                    <gml:LinearRing>
+                      <gml:posList>0.0 0.0 15.5 10.0 0.0 15.5 10.0 10.0 15.5 0.0 10.0 15.5 0.0 0.0 15.5</gml:posList>
+                    </gml:LinearRing>
+                  </gml:exterior>
+                </gml:Polygon>
+              </gml:surfaceMember>
+              <gml:surfaceMember>
+                <gml:Polygon>
+                  <gml:exterior>
+                    <gml:LinearRing>
+                      <gml:posList>0.0 0.0 0.0 10.0 0.0 0.0 10.0 0.0 15.5 0.0 0.0 15.5 0.0 0.0 0.0</gml:posList>
+                    </gml:LinearRing>
+                  </gml:exterior>
+                </gml:Polygon>
+              </gml:surfaceMember>
+              <gml:surfaceMember>
+                <gml:Polygon>
+                  <gml:exterior>
+                    <gml:LinearRing>
+                      <gml:posList>10.0 0.0 0.0 10.0 10.0 0.0 10.0 10.0 15.5 10.0 0.0 15.5 10.0 0.0 0.0</gml:posList>
+                    </gml:LinearRing>
+                  </gml:exterior>
+                </gml:Polygon>
+              </gml:surfaceMember>
+              <gml:surfaceMember>
+                <gml:Polygon>
+                  <gml:exterior>
+                    <gml:LinearRing>
+                      <gml:posList>10.0 10.0 0.0 0.0 10.0 0.0 0.0 10.0 15.5 10.0 10.0 15.5 10.0 10.0 0.0</gml:posList>
+                    </gml:LinearRing>
+                  </gml:exterior>
+                </gml:Polygon>
+              </gml:surfaceMember>
+              <gml:surfaceMember>
+                <gml:Polygon>
+                  <gml:exterior>
+                    <gml:LinearRing>
+                      <gml:posList>0.0 10.0 0.0 0.0 0.0 0.0 0.0 0.0 15.5 0.0 10.0 15.5 0.0 10.0 0.0</gml:posList>
+                    </gml:LinearRing>
+                  </gml:exterior>
+                </gml:Polygon>
+              </gml:surfaceMember>
+            </gml:CompositeSurface>
+          </gml:exterior>
+        </gml:Solid>
+      </bldg:lod2Solid>
+    </bldg:Building>
+  </cityObjectMember>
+  <cityObjectMember>
+    <bldg:Building gml:id="building2">
+      <bldg:yearOfConstruction>2015</bldg:yearOfConstruction>
+      <bldg:measuredHeight uom="m">8.2</bldg:measuredHeight>
+      <bldg:function>commercial</bldg:function>
+      <bldg:lod2Solid>
+        <gml:Solid>
+          <gml:exterior>
+            <gml:CompositeSurface>
+              <gml:surfaceMember>
+                <gml:Polygon>
+                  <gml:exterior>
+                    <gml:LinearRing>
+                      <gml:posList>20.0 0.0 0.0 30.0 0.0 0.0 30.0 10.0 0.0 20.0 10.0 0.0 20.0 0.0 0.0</gml:posList>
+                    </gml:LinearRing>
+                  </gml:exterior>
+                </gml:Polygon>
+              </gml:surfaceMember>
+              <gml:surfaceMember>
+                <gml:Polygon>
+                  <gml:exterior>
+                    <gml:LinearRing>
+                      <gml:posList>20.0 0.0 8.2 30.0 0.0 8.2 30.0 10.0 8.2 20.0 10.0 8.2 20.0 0.0 8.2</gml:posList>
+                    </gml:LinearRing>
+                  </gml:exterior>
+                </gml:Polygon>
+              </gml:surfaceMember>
+            </gml:CompositeSurface>
+          </gml:exterior>
+        </gml:Solid>
+      </bldg:lod2Solid>
+    </bldg:Building>
+  </cityObjectMember>
+</CityModel>

--- a/test/sql/citygml.test
+++ b/test/sql/citygml.test
@@ -1,0 +1,88 @@
+# name: test/sql/citygml.test
+# description: Test read_citygml and citygml_metadata table functions
+# group: [sql]
+
+require cityjson
+
+# Test basic CityGML reading
+statement ok
+CREATE TABLE gml_buildings AS SELECT * FROM read_citygml('test/data/minimal.gml');
+
+# Verify row count (2 buildings)
+query I
+SELECT COUNT(*) FROM gml_buildings;
+----
+2
+
+# Test object_type column
+query I
+SELECT COUNT(*) FROM gml_buildings WHERE object_type = 'Building';
+----
+2
+
+# Test attribute columns
+query I
+SELECT yearOfConstruction FROM gml_buildings WHERE id = 'building1';
+----
+2020
+
+query R
+SELECT measuredHeight FROM gml_buildings WHERE id = 'building1';
+----
+15.5
+
+query T
+SELECT function FROM gml_buildings WHERE id = 'building2';
+----
+commercial
+
+# Test feature_id column
+query I
+SELECT COUNT(*) FROM gml_buildings WHERE feature_id IS NOT NULL;
+----
+2
+
+# Test auto-detection via read_cityjson
+statement ok
+CREATE TABLE gml_auto AS SELECT * FROM read_cityjson('test/data/minimal.gml');
+
+query I
+SELECT COUNT(*) FROM gml_auto;
+----
+2
+
+query T
+SELECT object_type FROM gml_auto WHERE id = 'building1';
+----
+Building
+
+# Test LOD mode (WKB encoding)
+statement ok
+CREATE TABLE gml_lod AS SELECT * FROM read_citygml('test/data/minimal.gml', lod='2');
+
+query I
+SELECT COUNT(*) FROM gml_lod;
+----
+2
+
+# Verify geometry blob is not null
+query I
+SELECT COUNT(*) FROM gml_lod WHERE geometry IS NOT NULL;
+----
+2
+
+# Test citygml_metadata
+query I
+SELECT city_objects_count FROM citygml_metadata('test/data/minimal.gml');
+----
+2
+
+# Clean up
+statement ok
+DROP TABLE gml_buildings;
+
+statement ok
+DROP TABLE gml_auto;
+
+statement ok
+DROP TABLE gml_lod;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,8 @@
 {
         "dependencies": [
                 "openssl",
-                "nlohmann-json"
+                "nlohmann-json",
+                "pugixml"
         ],
         "vcpkg-configuration": {
                 "overlay-ports": [


### PR DESCRIPTION
## Summary

- Add `read_citygml(path)` and `citygml_metadata(path)` table functions for reading CityGML 2.0 XML files
- Parse CityGML XML (via pugixml) into the existing CityJSON internal data model with per-feature vertex pool deduplication
- Auto-detect `.gml`/`.citygml` files via `read_cityjson()` factory
- Support `lod=` and `sample_lines=` named parameters, local and remote files (HTTP, S3, GCS)
- Fix `IsGeometryColumn` regex to handle integer-only LOD strings (e.g. `geom_lod2`)

### Supported CityGML 2.0 features
- All CityJSON-compatible object types (Building, Road, WaterBody, Bridge, Tunnel, etc.)
- LOD 0–4 geometry (Solid, MultiSurface, CompositeSurface, MultiLineString, MultiSolid)
- Attribute extraction (measuredHeight, yearOfConstruction, function, etc.)
- Parent/child hierarchy (Building → BuildingPart)
- CRS from srsName (URN, EPSG:, OGC HTTP URI formats)
- Bounding box from `gml:Envelope`

### Known limitations
- xlink:href (shared geometries) not yet resolved
- Complex/nested CityGML attributes (e.g. `gen:stringAttribute`) silently skipped
- CityGML 3.0 not yet supported (planned as follow-up)
- Semantic surfaces not yet mapped to CityJSON semantics

## Test plan
- [x] `read_citygml` returns correct row count, object types, and attributes
- [x] `read_cityjson('file.gml')` auto-detects CityGML format
- [x] LOD/WKB mode produces geometry blobs and properties
- [x] `citygml_metadata` returns CRS, bounding box, and object count
- [x] Existing CityJSON/CityJSONSeq tests unaffected (215 assertions, 8 test cases pass)